### PR TITLE
VCP-1155: Add check for existence on tech call

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2144,7 +2144,11 @@ class Player extends Component {
 
       try {
         if (this.tech_) {
-          this.tech_[method](arg);
+          if (this.tech_[method]) {
+            this.tech_[method](arg);
+          } else {
+            log(`${method} is not defined on this tech. Tried calling with ${arg}.`);
+          }
         }
       } catch (e) {
         log(e);


### PR DESCRIPTION
Currently calls undefined methods on the techs which causes crashes.
If they are not defined it is because they are not supported, this will
help to reduce the number of stub methods and improve stability.